### PR TITLE
Add specify directories for publishing in the `files` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
   "documentationUrl": "https://github.com/nowsprinting/test-helper.input/blob/master/README.md",
   "files": [
     "Documentation~",
+    "Runtime",
     "Runtime*",
+    "Tests",
     "Tests*",
     "LICENSE.md*",
     "package.json*",


### PR DESCRIPTION
Maybe the glob rule changed for the `files` field from Node 16.
It seems `*` only applies to files and skips directories.

see: https://github.com/openupm/openupm-pipelines/issues/14
