### PR TITLE
Mod run tests as embedded package on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Koji Hasegawa.
+# Copyright (c) 2023-2024 Koji Hasegawa.
 # This software is released under the MIT License.
 
 name: Test
@@ -35,19 +35,13 @@ jobs:
       matrix:
         unityVersion: # Available versions see: https://game.ci/docs/docker/versions
           - 2019.4.40f1
-          - 2022.3.17f1
-          - 2023.2.5f1
+          - 2022.3.29f1
+          - 2023.2.20f1
         include:
           - unityVersion: 2019.4.40f1
             octocov: true
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          submodules: false
-          lfs: false
-
       - name: Crete project for tests
         uses: nowsprinting/create-unity-project-action@v3
         with:
@@ -60,21 +54,30 @@ jobs:
           restore-keys: |
             Library-
 
-      - name: Set package name
+      - name: Get package checkout path
         run: |
-          echo "package_name=$(grep -o -E '"name": "(.+)"' ./package.json | cut -d ' ' -f2)" >> "$GITHUB_ENV"
+          name=com.$(echo "${GITHUB_REPOSITORY}" | sed 's/\//\./g')
+          echo "PACKAGE_PATH=$CREATED_PROJECT_PATH/Packages/$name" >> "$GITHUB_ENV"
+
+      - name: Checkout repository as embedded package
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+          lfs: false
+          path: ${{ env.PACKAGE_PATH }}
+          # In Linux editor, there is a problem that assets in local packages cannot be found with `AssetDatabase.FindAssets`.
+          # As a workaround, I have made it into an embedded package.
 
       - name: Install dependencies
         run: |
           npm install -g openupm-cli
           openupm add -f com.unity.test-framework
           openupm add -f com.unity.testtools.codecoverage
-          openupm add -ft "${{ env.package_name }}"@file:../../
         working-directory: ${{ env.CREATED_PROJECT_PATH }}
 
       - name: Set coverage assembly filters
         run: |
-          assemblies=$(find . -name "*.asmdef" -maxdepth 3 | sed -e s/.*\\//\+/ | sed -e s/\\.asmdef// | sed -e s/^.*\\.Tests//)
+          assemblies=$(find ${{ env.PACKAGE_PATH }} -name "*.asmdef" | sed -e s/.*\\//\+/ | sed -e s/\\.asmdef// | sed -e s/^.*\\.Tests//)
           # shellcheck disable=SC2001,SC2048,SC2086
           echo "assembly_filters=$(echo ${assemblies[*]} | sed -e s/\ /,/g),+<assets>,-*.Tests" >> "$GITHUB_ENV"
 
@@ -88,7 +91,7 @@ jobs:
           unityVersion: ${{ matrix.unityVersion }}  # Default is `auto`
           checkName: test result (${{ matrix.unityVersion }})
           projectPath: ${{ env.CREATED_PROJECT_PATH }}
-          customParameters: -testCategory "!IgnoreCI"
+          customParameters: -testCategory "!IgnoreCI" -testHelperScreenshotDirectory /github/workspace/artifacts/Screenshots
           coverageOptions: generateAdditionalMetrics;generateTestReferences;generateHtmlReport;generateAdditionalReports;dontClear;assemblyFilters:${{ env.assembly_filters }}
           # see: https://docs.unity3d.com/Packages/com.unity.testtools.codecoverage@1.2/manual/CoverageBatchmode.html
         env:
@@ -98,7 +101,9 @@ jobs:
         id: test
 
       - name: Set coverage path for octocov
-        run: sed -i -r 's/\.\/Logs/${{ steps.test.outputs.coveragePath }}/' .octocov.yml
+        run: |
+          mv ${{ env.PACKAGE_PATH }}/.octocov.yml .
+          sed -i -r 's/UnityProject~\/Logs/${{ steps.test.outputs.coveragePath }}/' .octocov.yml
         if: ${{ matrix.octocov }}
 
       - name: Run octocov

--- a/.octocov.yml
+++ b/.octocov.yml
@@ -2,18 +2,20 @@
 coverage:
   if: true
   paths:
-    - ./Logs/Report/lcov.info # Warning: This path is replace by regex in test.yml
+    - UnityProject~/Logs/Report/lcov.info # Warning: This path is to be replaced by regex in test.yml
+
 codeToTestRatio:
   code:
-    - 'Editor/**/*.cs'
-    - 'Runtime/**/*.cs'
-    - 'Samples~/**/*.cs'
-    - '!Samples~/**/Tests/**/*.cs'
+    - '**/*.cs'
+    - '!**/Tests/**'
+    - '!UnityProject~/Library/**'
   test:
-    - 'Tests/**/*.cs'
-    - 'Samples~/**/Tests/**/*.cs'
+    - '**/Tests/**/*.cs'
+    - '!UnityProject~/Library/**'
+
 testExecutionTime:
   if: true
+
 diff:
   datastores:
     - artifact://${GITHUB_REPOSITORY}


### PR DESCRIPTION
### Changes

#### Fix paths in .octocov.yml
- Fix code coverage store directory when running via Makefile.
- Make simplify "Code to Test Ratio" setting.

#### Mod run tests as embedded package on CI
In Linux editor, there is a problem that assets in local packages cannot be found with `AssetDatabase.FindAssets`.
As a workaround, I have made it into an embedded package.