### PR TITLE
Fix workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,4 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: weekly

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -17,6 +17,7 @@ on:
 jobs:
   actionlint:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   create-release-pr:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/metacheck.yml
+++ b/.github/workflows/metacheck.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   meta-check:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -11,6 +11,7 @@ jobs:
   pr-labeler:
     if: github.event.pull_request.head.repo.fork == false # Skip on public fork
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -17,6 +17,7 @@ jobs:
   release-drafter:
     if: github.repository_owner == 'nowsprinting' # Skip on forked repo
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: write
       pull-requests: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
   check-bump-version:
     if: github.repository_owner == 'nowsprinting' # Skip on forked repo
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
     outputs:
@@ -34,6 +35,7 @@ jobs:
     needs: check-bump-version
     if: ${{ needs.check-bump-version.outputs.new-version }}
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: write
       pull-requests: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,9 +51,11 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: ${{ env.CREATED_PROJECT_PATH }}/Library
-          key: Library-${{ matrix.unityVersion }}
+          key: Library-linux-${{ matrix.unityVersion }}-${{ github.ref }}
           restore-keys: |
-            Library-
+            Library-linux-${{ matrix.unityVersion }}
+            Library-linux
+            Library
 
       - name: Get package checkout path
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Install dependencies
         run: |
           npm install -g openupm-cli
-          openupm add -f com.unity.test-framework
+          openupm add -f com.unity.test-framework@stable
           openupm add -f com.unity.testtools.codecoverage
         working-directory: ${{ env.CREATED_PROJECT_PATH }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ jobs:
   test:
     if: github.event.pull_request.head.repo.fork == false # Skip on public fork, because can not read secrets.
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
       checks: write
@@ -123,6 +124,7 @@ jobs:
     needs: test
     if: github.event.pull_request.head.repo.fork == false # Skip on public fork, because can not read secrets.
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       actions: read
 

--- a/Makefile
+++ b/Makefile
@@ -121,10 +121,10 @@ create_project:
 	  -createProject $(PROJECT_HOME) \
 	  -batchmode \
 	  -quit
-	touch UnityProject~/Assets/.gitkeep
-	openupm -c $(PROJECT_HOME) add -f com.unity.test-framework@stable
-	openupm -c $(PROJECT_HOME) add -f com.unity.testtools.codecoverage
-	openupm -c $(PROJECT_HOME) add -ft $(PACKAGE_NAME)@file:../../
+	touch $(PROJECT_HOME)/Assets/.gitkeep
+	openupm add -c $(PROJECT_HOME) -f com.unity.test-framework@stable
+	openupm add -c $(PROJECT_HOME) -f com.unity.testtools.codecoverage
+	openupm add -c $(PROJECT_HOME) -ft $(PACKAGE_NAME)@file:../../
 
 .PHONY: remove_project
 remove_project:

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ endif
 
 define base_arguments
 -projectPath $(PROJECT_HOME) \
--logFile $(LOG_DIR)/test_$(TEST_PLATFORM).log
+-logFile $(LOG_DIR)/$(TEST_PLATFORM).log
 endef
 
 define test_arguments
@@ -64,7 +64,9 @@ $(TEST_CATEGORY) \
 $(TEST_FILTER) \
 $(ASSEMBLY_NAMES) \
 -testPlatform $(TEST_PLATFORM) \
--testResults $(LOG_DIR)/test_$(TEST_PLATFORM)_results.xml
+-testResults $(LOG_DIR)/$(TEST_PLATFORM)-results.xml \
+-testHelperJUnitResults $(LOG_DIR)/$(TEST_PLATFORM)-junit-results.xml \
+-testHelperScreenshotDirectory $(LOG_DIR)/Screenshots
 endef
 
 define test

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ PACKAGE_NAME?=$(shell grep -o -E '"name": "(.+)"' $(PACKAGE_HOME)/package.json |
 
 # Code Coverage report filter (comma separated)
 # see: https://docs.unity3d.com/Packages/com.unity.testtools.codecoverage@1.2/manual/CoverageBatchmode.html
-PACKAGE_ASSEMBLIES?=$(shell echo $(shell find $(PACKAGE_HOME) -name "*.asmdef" -maxdepth 3 | sed -e s/.*\\//\+/ | sed -e s/\\.asmdef// | sed -e s/^.*\\.Tests//) | sed -e s/\ /,/g)
+PACKAGE_ASSEMBLIES?=$(shell echo $(shell find $(PACKAGE_HOME) -name "*.asmdef" | grep -v -E "\/UnityProject~\/" | sed -e s/.*\\//\+/ | sed -e s/\\.asmdef// | sed -e s/^.*\\.Tests//) | sed -e s/\ /,/g)
 COVERAGE_ASSEMBLY_FILTERS?=$(PACKAGE_ASSEMBLIES),+<assets>,-*.Tests
 
 # -nographics` option

--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ create_project:
 	  -batchmode \
 	  -quit
 	touch UnityProject~/Assets/.gitkeep
-	openupm -c $(PROJECT_HOME) add -f com.unity.test-framework
+	openupm -c $(PROJECT_HOME) add -f com.unity.test-framework@stable
 	openupm -c $(PROJECT_HOME) add -f com.unity.testtools.codecoverage
 	openupm -c $(PROJECT_HOME) add -ft $(PACKAGE_NAME)@file:../../
 


### PR DESCRIPTION
### Changes

- Mod dependency check interval to weekly
- Add timeout-minutes
- Add github.ref into cache key
- Add `@stable` virtual dist-tag when installing test-framework package
- Mod openupm command option
- Mod log file names to same to game-ci/unity-test-runner
- Fix to code coverage exclude test project assemblies